### PR TITLE
feat: Support ruff's sarif output and .ruff.toml config

### DIFF
--- a/linters/ruff/plugin.yaml
+++ b/linters/ruff/plugin.yaml
@@ -12,6 +12,20 @@ lint:
       description: A Python linter and formatter
       commands:
         - name: lint
+          # As of ruff v0.1.8, ruff supports sarif output format.
+          # Here we use ruff's sarif output instead of doing json->sarif parsing.
+          # Ruff's sarif output may not have autofix suggestions like json output.
+          # Also 'ruleId' maybe null, which will be handled by a new custom parser.
+          version: ">=0.9.9"
+          files: [python, python-interface, jupyter]
+          run: ruff check --cache-dir ${cachedir} --output-format sarif ${target}
+          output: sarif
+          parser:
+            runtime: python
+            run: python3 ${cwd}/ruff_sarif_to_trunk_sarif.py
+          batch: true
+          success_codes: [0, 1]
+        - name: lint
           # As of ruff v0.6.0, ruff runs by default on jupyter notebooks
           version: ">=0.6.0"
           files: [python, python-interface, jupyter]
@@ -45,12 +59,12 @@ lint:
           batch: true
           success_codes: [0, 1]
         - name: lint
-          files: [python, python-interface]
-          run: ruff check --cache-dir ${cachedir} --format json ${target}
+          files: [python, python-interface, jupyter]
+          run: ruff check --cache-dir ${cachedir} --output-format sarif ${target}
           output: sarif
           parser:
             runtime: python
-            run: python3 ${cwd}/ruff_to_sarif.py 1
+            run: python3 ${cwd}/ruff_sarif_to_trunk_sarif.py
           batch: true
           success_codes: [0, 1]
         - name: format
@@ -65,7 +79,7 @@ lint:
           formatter: true
           enabled: false
       tools: [ruff]
-      direct_configs: [ruff.toml]
+      direct_configs: [.ruff.toml, ruff.toml]
       affects_cache:
         - pyproject.toml
         - setup.cfg
@@ -90,7 +104,7 @@ lint:
       runtime: python
       package: ruff
       extra_packages: [nbqa==1.8.5]
-      direct_configs: [ruff.toml]
+      direct_configs: [.ruff.toml, ruff.toml]
       affects_cache:
         - pyproject.toml
         - setup.cfg

--- a/linters/ruff/ruff_sarif_to_trunk_sarif.py
+++ b/linters/ruff/ruff_sarif_to_trunk_sarif.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+
+import json
+import sys
+
+results = []
+for run in json.load(sys.stdin).get("runs", []):
+    for result in run.get("results", []):
+        # Ruff will set code to null for syntax errors
+        if result["ruleId"] is None:
+            result["ruleId"] = "E999"
+        results.append(result)
+
+sarif = {
+    "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
+    "version": "2.1.0",
+    "runs": [{"results": results}],
+}
+
+print(json.dumps(sarif, indent=2))

--- a/linters/ruff/test_data/ruff_v0.9.9_basic.check.shot
+++ b/linters/ruff/test_data/ruff_v0.9.9_basic.check.shot
@@ -1,0 +1,88 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing linter ruff test basic 1`] = `
+{
+  "issues": [
+    {
+      "code": "E402",
+      "column": "1",
+      "file": "test_data/basic.in.py",
+      "issueClass": "ISSUE_CLASS_EXISTING",
+      "issueUrl": "https://docs.astral.sh/ruff/rules/#E402",
+      "level": "LEVEL_HIGH",
+      "line": "7",
+      "linter": "ruff",
+      "message": "Module level import not at top of file",
+      "ranges": [
+        {
+          "filePath": "test_data/basic.in.py",
+          "length": "10",
+          "offset": "83",
+        },
+      ],
+      "targetType": "python",
+    },
+    {
+      "code": "F401",
+      "column": "8",
+      "file": "test_data/basic.in.py",
+      "issueClass": "ISSUE_CLASS_EXISTING",
+      "issueUrl": "https://docs.astral.sh/ruff/rules/#F401",
+      "level": "LEVEL_HIGH",
+      "line": "7",
+      "linter": "ruff",
+      "message": "\`sys\` imported but unused",
+      "ranges": [
+        {
+          "filePath": "test_data/basic.in.py",
+          "length": "3",
+          "offset": "90",
+        },
+      ],
+      "targetType": "python",
+    },
+    {
+      "code": "E402",
+      "column": "1",
+      "file": "test_data/basic.in.py",
+      "issueClass": "ISSUE_CLASS_EXISTING",
+      "issueUrl": "https://docs.astral.sh/ruff/rules/#E402",
+      "level": "LEVEL_HIGH",
+      "line": "9",
+      "linter": "ruff",
+      "message": "Module level import not at top of file",
+      "ranges": [
+        {
+          "filePath": "test_data/basic.in.py",
+          "length": "11",
+          "offset": "120",
+        },
+      ],
+      "targetType": "python",
+    },
+  ],
+  "lintActions": [
+    {
+      "command": "lint",
+      "fileGroupName": "python",
+      "linter": "ruff",
+      "paths": [
+        "test_data/basic.in.py",
+      ],
+      "verb": "TRUNK_VERB_CHECK",
+    },
+    {
+      "command": "lint",
+      "fileGroupName": "python",
+      "linter": "ruff",
+      "paths": [
+        "test_data/basic.in.py",
+      ],
+      "upstream": true,
+      "verb": "TRUNK_VERB_CHECK",
+    },
+  ],
+  "taskFailures": [],
+  "unformattedFiles": [],
+}
+`;

--- a/linters/ruff/test_data/ruff_v0.9.9_basic_nb.check.shot
+++ b/linters/ruff/test_data/ruff_v0.9.9_basic_nb.check.shot
@@ -1,0 +1,43 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing linter ruff test basic_nb 1`] = `
+{
+  "issues": [
+    {
+      "code": "F401",
+      "column": "1",
+      "file": "test_data/basic_nb.in.ipynb",
+      "issueClass": "ISSUE_CLASS_EXISTING",
+      "issueUrl": "https://docs.astral.sh/ruff/rules/#F401",
+      "level": "LEVEL_HIGH",
+      "line": "1",
+      "linter": "ruff",
+      "message": "\`os\` imported but unused",
+      "targetType": "jupyter",
+    },
+  ],
+  "lintActions": [
+    {
+      "command": "lint",
+      "fileGroupName": "jupyter",
+      "linter": "ruff",
+      "paths": [
+        "test_data/basic_nb.in.ipynb",
+      ],
+      "verb": "TRUNK_VERB_CHECK",
+    },
+    {
+      "command": "lint",
+      "fileGroupName": "jupyter",
+      "linter": "ruff",
+      "paths": [
+        "test_data/basic_nb.in.ipynb",
+      ],
+      "upstream": true,
+      "verb": "TRUNK_VERB_CHECK",
+    },
+  ],
+  "taskFailures": [],
+  "unformattedFiles": [],
+}
+`;

--- a/linters/ruff/test_data/ruff_v0.9.9_interface.check.shot
+++ b/linters/ruff/test_data/ruff_v0.9.9_interface.check.shot
@@ -1,0 +1,183 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing linter ruff test interface 1`] = `
+{
+  "issues": [
+    {
+      "code": "F821",
+      "column": "2",
+      "file": "test_data/interface.in.pyi",
+      "issueClass": "ISSUE_CLASS_EXISTING",
+      "issueUrl": "https://docs.astral.sh/ruff/rules/#F821",
+      "level": "LEVEL_HIGH",
+      "line": "11",
+      "linter": "ruff",
+      "message": "Undefined name \`overload\`",
+      "ranges": [
+        {
+          "filePath": "test_data/interface.in.pyi",
+          "length": "8",
+          "offset": "170",
+        },
+      ],
+      "targetType": "python-interface",
+    },
+    {
+      "code": "F811",
+      "column": "5",
+      "file": "test_data/interface.in.pyi",
+      "issueClass": "ISSUE_CLASS_EXISTING",
+      "issueUrl": "https://docs.astral.sh/ruff/rules/#F811",
+      "level": "LEVEL_HIGH",
+      "line": "12",
+      "linter": "ruff",
+      "message": "Redefinition of unused \`a\` from line 9",
+      "ranges": [
+        {
+          "filePath": "test_data/interface.in.pyi",
+          "length": "1",
+          "offset": "183",
+        },
+      ],
+      "targetType": "python-interface",
+    },
+    {
+      "code": "F821",
+      "column": "2",
+      "file": "test_data/interface.in.pyi",
+      "issueClass": "ISSUE_CLASS_EXISTING",
+      "issueUrl": "https://docs.astral.sh/ruff/rules/#F821",
+      "level": "LEVEL_HIGH",
+      "line": "14",
+      "linter": "ruff",
+      "message": "Undefined name \`overload\`",
+      "ranges": [
+        {
+          "filePath": "test_data/interface.in.pyi",
+          "length": "8",
+          "offset": "202",
+        },
+      ],
+      "targetType": "python-interface",
+    },
+    {
+      "code": "F811",
+      "column": "5",
+      "file": "test_data/interface.in.pyi",
+      "issueClass": "ISSUE_CLASS_EXISTING",
+      "issueUrl": "https://docs.astral.sh/ruff/rules/#F811",
+      "level": "LEVEL_HIGH",
+      "line": "15",
+      "linter": "ruff",
+      "message": "Redefinition of unused \`a\` from line 12",
+      "ranges": [
+        {
+          "filePath": "test_data/interface.in.pyi",
+          "length": "1",
+          "offset": "215",
+        },
+      ],
+      "targetType": "python-interface",
+    },
+    {
+      "code": "F401",
+      "column": "8",
+      "file": "test_data/interface.in.pyi",
+      "issueClass": "ISSUE_CLASS_EXISTING",
+      "issueUrl": "https://docs.astral.sh/ruff/rules/#F401",
+      "level": "LEVEL_HIGH",
+      "line": "2",
+      "linter": "ruff",
+      "message": "\`json\` imported but unused",
+      "ranges": [
+        {
+          "filePath": "test_data/interface.in.pyi",
+          "length": "4",
+          "offset": "54",
+        },
+      ],
+      "targetType": "python-interface",
+    },
+    {
+      "code": "F821",
+      "column": "6",
+      "file": "test_data/interface.in.pyi",
+      "issueClass": "ISSUE_CLASS_EXISTING",
+      "issueUrl": "https://docs.astral.sh/ruff/rules/#F821",
+      "level": "LEVEL_HIGH",
+      "line": "31",
+      "linter": "ruff",
+      "message": "Undefined name \`decorated\`",
+      "ranges": [
+        {
+          "filePath": "test_data/interface.in.pyi",
+          "length": "9",
+          "offset": "479",
+        },
+      ],
+      "targetType": "python-interface",
+    },
+    {
+      "code": "F811",
+      "column": "1",
+      "file": "test_data/interface.in.pyi",
+      "issueClass": "ISSUE_CLASS_EXISTING",
+      "issueUrl": "https://docs.astral.sh/ruff/rules/#F811",
+      "level": "LEVEL_HIGH",
+      "line": "37",
+      "linter": "ruff",
+      "message": "Redefinition of unused \`a\` from line 15",
+      "ranges": [
+        {
+          "filePath": "test_data/interface.in.pyi",
+          "length": "1",
+          "offset": "548",
+        },
+      ],
+      "targetType": "python-interface",
+    },
+    {
+      "code": "F401",
+      "column": "25",
+      "file": "test_data/interface.in.pyi",
+      "issueClass": "ISSUE_CLASS_EXISTING",
+      "issueUrl": "https://docs.astral.sh/ruff/rules/#F401",
+      "level": "LEVEL_HIGH",
+      "line": "4",
+      "linter": "ruff",
+      "message": "\`typing.Sequence\` imported but unused",
+      "ranges": [
+        {
+          "filePath": "test_data/interface.in.pyi",
+          "length": "8",
+          "offset": "84",
+        },
+      ],
+      "targetType": "python-interface",
+    },
+  ],
+  "lintActions": [
+    {
+      "command": "lint",
+      "fileGroupName": "python-interface",
+      "linter": "ruff",
+      "paths": [
+        "test_data/interface.in.pyi",
+      ],
+      "verb": "TRUNK_VERB_CHECK",
+    },
+    {
+      "command": "lint",
+      "fileGroupName": "python-interface",
+      "linter": "ruff",
+      "paths": [
+        "test_data/interface.in.pyi",
+      ],
+      "upstream": true,
+      "verb": "TRUNK_VERB_CHECK",
+    },
+  ],
+  "taskFailures": [],
+  "unformattedFiles": [],
+}
+`;

--- a/linters/ruff/test_data/ruff_v0.9.9_syntax.check.shot
+++ b/linters/ruff/test_data/ruff_v0.9.9_syntax.check.shot
@@ -1,0 +1,43 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing linter ruff test syntax 1`] = `
+{
+  "issues": [
+    {
+      "code": "E999",
+      "column": "1",
+      "file": "test_data/syntax.in.py",
+      "issueClass": "ISSUE_CLASS_EXISTING",
+      "issueUrl": "https://docs.astral.sh/ruff/rules/#E999",
+      "level": "LEVEL_HIGH",
+      "line": "2",
+      "linter": "ruff",
+      "message": "SyntaxError: unexpected EOF while parsing",
+      "targetType": "python",
+    },
+  ],
+  "lintActions": [
+    {
+      "command": "lint",
+      "fileGroupName": "python",
+      "linter": "ruff",
+      "paths": [
+        "test_data/syntax.in.py",
+      ],
+      "verb": "TRUNK_VERB_CHECK",
+    },
+    {
+      "command": "lint",
+      "fileGroupName": "python",
+      "linter": "ruff",
+      "paths": [
+        "test_data/syntax.in.py",
+      ],
+      "upstream": true,
+      "verb": "TRUNK_VERB_CHECK",
+    },
+  ],
+  "taskFailures": [],
+  "unformattedFiles": [],
+}
+`;


### PR DESCRIPTION
### **PR Type**
Enhancement, Tests


___

### **Description**
- Added support for Ruff's SARIF output format.

- Introduced a custom parser to handle `ruleId` null cases.

- Updated `plugin.yaml` to include `.ruff.toml` configuration support.

- Added comprehensive test snapshots for Ruff linter functionality.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ruff_sarif_to_trunk_sarif.py</strong><dd><code>Add custom parser for Ruff SARIF output</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

linters/ruff/ruff_sarif_to_trunk_sarif.py

<li>Added a script to convert Ruff SARIF output to Trunk SARIF.<br> <li> Handles cases where <code>ruleId</code> is null by assigning "E999".<br> <li> Outputs a formatted SARIF JSON structure.


</details>


  </td>
  <td><a href="https://github.com/NextGenContributions/plugins/pull/2/files#diff-657f490e8f9961d377cb7e951cf9be11e3c395314bf0f26f2df5072bb2791ee9">+20/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>plugin.yaml</strong><dd><code>Update plugin configuration for Ruff SARIF and `.ruff.toml`</code></dd></summary>
<hr>

linters/ruff/plugin.yaml

<li>Updated to use Ruff's SARIF output format for linting.<br> <li> Added <code>.ruff.toml</code> as a direct configuration file.<br> <li> Adjusted commands and parsers to align with Ruff v0.9.9.<br> <li> Enhanced support for Jupyter notebooks and Python interfaces.


</details>


  </td>
  <td><a href="https://github.com/NextGenContributions/plugins/pull/2/files#diff-41182abac74ebb742d58ca67de6f4bd588ddfaafedb2cfe14ae635962a176466">+19/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ruff_v0.9.9_basic.check.shot</strong><dd><code>Add test snapshot for basic Ruff linting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

linters/ruff/test_data/ruff_v0.9.9_basic.check.shot

<li>Added test snapshot for basic Ruff linting functionality.<br> <li> Includes issues like unused imports and incorrect module imports.


</details>


  </td>
  <td><a href="https://github.com/NextGenContributions/plugins/pull/2/files#diff-e2e8aa2034c11d8c6c8bc2b5bf8476809665925e24532f126830f7465126c28e">+88/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ruff_v0.9.9_basic_nb.check.shot</strong><dd><code>Add test snapshot for Ruff on Jupyter notebooks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

linters/ruff/test_data/ruff_v0.9.9_basic_nb.check.shot

<li>Added test snapshot for Ruff linting on Jupyter notebooks.<br> <li> Captures unused imports in notebook files.


</details>


  </td>
  <td><a href="https://github.com/NextGenContributions/plugins/pull/2/files#diff-e11ced120264d64f449b3f489b7381e5a44418760d92192029620f40e073ff5d">+43/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ruff_v0.9.9_interface.check.shot</strong><dd><code>Add test snapshot for Ruff on Python interfaces</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

linters/ruff/test_data/ruff_v0.9.9_interface.check.shot

<li>Added test snapshot for Ruff linting on Python interfaces.<br> <li> Includes issues like undefined names and redefinitions.


</details>


  </td>
  <td><a href="https://github.com/NextGenContributions/plugins/pull/2/files#diff-153b7eb9e590687ea87b82b4c5ce1194edb6470978b0630e7dc808515f5f1c11">+183/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ruff_v0.9.9_syntax.check.shot</strong><dd><code>Add test snapshot for Ruff syntax error handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

linters/ruff/test_data/ruff_v0.9.9_syntax.check.shot

<li>Added test snapshot for Ruff syntax error handling.<br> <li> Captures unexpected EOF errors with <code>E999</code> code.


</details>


  </td>
  <td><a href="https://github.com/NextGenContributions/plugins/pull/2/files#diff-04af7a7aaa44e006f63fcd9f71c7ef2cbfd0dc877f0544d295c8f728428358b4">+43/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/NextGenContributions/plugins/2)
<!-- Reviewable:end -->
